### PR TITLE
Limit Camera Movement

### DIFF
--- a/Assets/Scenes/Carson.meta
+++ b/Assets/Scenes/Carson.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f54f33ca32da9e45919d60fc1bf337c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Carson/Traversal Test.unity.meta
+++ b/Assets/Scenes/Carson/Traversal Test.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6fed9c3597d86814897ff932cffe87b2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Controllers/CameraController.cs
+++ b/Assets/Scripts/Controllers/CameraController.cs
@@ -19,6 +19,10 @@ public class CameraController : Singleton<CameraController>
     private float panSensitivity = 5f;
     [SerializeField]
     private float distanceFrom = 5.0f;
+    [SerializeField]
+    private GameObject corner1;
+    [SerializeField]
+    private GameObject corner2;
 
     private CinemachineBrain _cinemachineBrain;
     private CinemachineVirtualCamera _cinemachineCam;
@@ -33,6 +37,9 @@ public class CameraController : Singleton<CameraController>
     private bool _rotateCamera;
     private bool _panCamera;
     private LayerMask _hitMask;
+
+    private Vector3 cornerPos1;
+    private Vector3 cornerPos2;
 
     public Camera MainCamera {
         get => mainCamera;
@@ -89,6 +96,13 @@ public class CameraController : Singleton<CameraController>
 
         _panCamera = false;
         _rotateCamera = false;
+
+        cornerPos1 = new Vector3(Mathf.Max(corner1.transform.position.x, corner2.transform.position.x), 
+                                            Mathf.Max(corner1.transform.position.y, corner2.transform.position.y), 
+                                            Mathf.Max(corner1.transform.position.z, corner2.transform.position.z));
+        cornerPos2 = new Vector3(Mathf.Min(corner1.transform.position.x, corner2.transform.position.x), 
+                                            Mathf.Min(corner1.transform.position.y, corner2.transform.position.y), 
+                                            Mathf.Min(corner1.transform.position.z, corner2.transform.position.z));
     }
 
     public void StartRotateCamera() {
@@ -122,6 +136,14 @@ public class CameraController : Singleton<CameraController>
     }
     public void PanCamera(Vector2 mouseDelta) {
         _currentPos += ((-_lookAt.up * mouseDelta.y) + (-_lookAt.right * mouseDelta.x)) * panSensitivity / 100f;
+
+        _currentPos.x = _currentPos.x > cornerPos1.x ? cornerPos1.x : _currentPos.x;
+        _currentPos.y = _currentPos.y > cornerPos1.y ? cornerPos1.y : _currentPos.y;
+        _currentPos.z = _currentPos.z > cornerPos1.z ? cornerPos1.z : _currentPos.z;
+
+        _currentPos.x = _currentPos.x < cornerPos2.x ? cornerPos2.x : _currentPos.x;
+        _currentPos.y = _currentPos.y < cornerPos2.y ? cornerPos2.y : _currentPos.y;
+        _currentPos.z = _currentPos.z < cornerPos2.z ? cornerPos2.z : _currentPos.z;
     }
 
     public void ZoomCamera(float zoom) {

--- a/Assets/Scripts/Controllers/CameraController.cs
+++ b/Assets/Scripts/Controllers/CameraController.cs
@@ -38,8 +38,8 @@ public class CameraController : Singleton<CameraController>
     private bool _panCamera;
     private LayerMask _hitMask;
 
-    private Vector3 cornerPos1;
-    private Vector3 cornerPos2;
+    private Vector3 cornerMaxPos;
+    private Vector3 cornerMinPos;
 
     public Camera MainCamera {
         get => mainCamera;
@@ -97,10 +97,10 @@ public class CameraController : Singleton<CameraController>
         _panCamera = false;
         _rotateCamera = false;
 
-        cornerPos1 = new Vector3(Mathf.Max(corner1.transform.position.x, corner2.transform.position.x), 
+        cornerMaxPos = new Vector3(Mathf.Max(corner1.transform.position.x, corner2.transform.position.x), 
                                             Mathf.Max(corner1.transform.position.y, corner2.transform.position.y), 
                                             Mathf.Max(corner1.transform.position.z, corner2.transform.position.z));
-        cornerPos2 = new Vector3(Mathf.Min(corner1.transform.position.x, corner2.transform.position.x), 
+        cornerMinPos = new Vector3(Mathf.Min(corner1.transform.position.x, corner2.transform.position.x), 
                                             Mathf.Min(corner1.transform.position.y, corner2.transform.position.y), 
                                             Mathf.Min(corner1.transform.position.z, corner2.transform.position.z));
     }
@@ -137,13 +137,14 @@ public class CameraController : Singleton<CameraController>
     public void PanCamera(Vector2 mouseDelta) {
         _currentPos += ((-_lookAt.up * mouseDelta.y) + (-_lookAt.right * mouseDelta.x)) * panSensitivity / 100f;
 
-        _currentPos.x = _currentPos.x > cornerPos1.x ? cornerPos1.x : _currentPos.x;
-        _currentPos.y = _currentPos.y > cornerPos1.y ? cornerPos1.y : _currentPos.y;
-        _currentPos.z = _currentPos.z > cornerPos1.z ? cornerPos1.z : _currentPos.z;
+        // Limit camera to the bounds given by corner1 and corner2
+        _currentPos.x = _currentPos.x > cornerMaxPos.x ? cornerMaxPos.x : _currentPos.x;
+        _currentPos.y = _currentPos.y > cornerMaxPos.y ? cornerMaxPos.y : _currentPos.y;
+        _currentPos.z = _currentPos.z > cornerMaxPos.z ? cornerMaxPos.z : _currentPos.z;
 
-        _currentPos.x = _currentPos.x < cornerPos2.x ? cornerPos2.x : _currentPos.x;
-        _currentPos.y = _currentPos.y < cornerPos2.y ? cornerPos2.y : _currentPos.y;
-        _currentPos.z = _currentPos.z < cornerPos2.z ? cornerPos2.z : _currentPos.z;
+        _currentPos.x = _currentPos.x < cornerMinPos.x ? cornerMinPos.x : _currentPos.x;
+        _currentPos.y = _currentPos.y < cornerMinPos.y ? cornerMinPos.y : _currentPos.y;
+        _currentPos.z = _currentPos.z < cornerMinPos.z ? cornerMinPos.z : _currentPos.z;
     }
 
     public void ZoomCamera(float zoom) {


### PR DESCRIPTION
Limit camera movement to within the bounds given by two corners of the grid.

To use: give the CameraController references to the two corners which bound the LevelGrid in Corner 1 and Corner 2.

To test: Give the two corners, and try to pan out of bounds. You should (99.99% sure) not be able to move the camera out of bounds.

Changes can be seen in Scenes/Carson/Traversal Test.unity